### PR TITLE
Check for symlinked gitconfig

### DIFF
--- a/src/git-auth-helper.ts
+++ b/src/git-auth-helper.ts
@@ -104,8 +104,16 @@ class GitAuthHelper {
       }
     }
     if (configExists) {
-      core.info(`Copying '${gitConfigPath}' to '${newGitConfigPath}'`)
-      await io.cp(gitConfigPath, newGitConfigPath)
+      if ((await ioUtil.lstat(gitConfigPath)).isSymbolicLink()) {
+        core.info(`.gitconfig file at ${gitConfigPath} is a symlink, copying the true file instead`)
+        // get true link
+        const symlinkFull: string = await ioUtil.readlink(srcFile)
+        core.info(`Copying '${symlinkFull}' to '${newGitConfigPath}'`)
+        await io.cp(symlinkFull, newGitConfigPath)
+      } else {
+        core.info(`Copying '${gitConfigPath}' to '${newGitConfigPath}'`)
+        await io.cp(gitConfigPath, newGitConfigPath)
+      }
     } else {
       await fs.promises.writeFile(newGitConfigPath, '')
     }


### PR DESCRIPTION
We don't want to edit the user's actual gitconfig, we only want to copy their setup. If the file is symlinked, we copy the destination file instead.